### PR TITLE
Add on_postgres_error and on_postgres_timing to public API of RequestHanderMixin

### DIFF
--- a/sprockets_postgres.py
+++ b/sprockets_postgres.py
@@ -602,8 +602,8 @@ class RequestHandlerMixin:
 
         """
         async with self.application.postgres_connector(
-                self._on_postgres_error,
-                self._on_postgres_timing,
+                self.on_postgres_error,
+                self.on_postgres_timing,
                 timeout) as connector:
             return await connector.callproc(
                 name, parameters, metric_name, timeout=timeout)
@@ -641,8 +641,8 @@ class RequestHandlerMixin:
 
         """
         async with self.application.postgres_connector(
-                self._on_postgres_error,
-                self._on_postgres_timing,
+                self.on_postgres_error,
+                self.on_postgres_timing,
                 timeout) as connector:
             return await connector.execute(
                 sql, parameters, metric_name, timeout=timeout)
@@ -688,15 +688,15 @@ class RequestHandlerMixin:
 
         """
         async with self.application.postgres_connector(
-                self._on_postgres_error,
-                self._on_postgres_timing,
+                self.on_postgres_error,
+                self.on_postgres_timing,
                 timeout) as connector:
             async with connector.transaction():
                 yield connector
 
-    def _on_postgres_error(self,
-                           metric_name: str,
-                           exc: Exception) -> typing.Optional[Exception]:
+    def on_postgres_error(self,
+                          metric_name: str,
+                          exc: Exception) -> typing.Optional[Exception]:
         """Override for different error handling behaviors
 
         Return an exception if you would like for it to be raised, or swallow
@@ -716,9 +716,9 @@ class RequestHandlerMixin:
             raise web.HTTPError(500, reason='Database Error')
         return exc
 
-    def _on_postgres_timing(self,
-                            metric_name: str,
-                            duration: float) -> None:
+    def on_postgres_timing(self,
+                           metric_name: str,
+                           duration: float) -> None:
         """Override for custom metric recording. As a default behavior it will
         attempt to detect `sprockets-influxdb
         <https://sprockets-influxdb.readthedocs.io/>`_ and

--- a/tests.py
+++ b/tests.py
@@ -69,16 +69,16 @@ class ErrorRequestHandler(RequestHandler):
         await self.postgres_execute(self.GET_SQL)
         self.set_status(204)
 
-    def _on_postgres_error(self,
-                           metric_name: str,
-                           exc: Exception) -> typing.Optional[Exception]:
+    def on_postgres_error(self,
+                          metric_name: str,
+                          exc: Exception) -> typing.Optional[Exception]:
         return RuntimeError()
 
 
 class ErrorPassthroughRequestHandler(RequestHandler):
 
     async def get(self):
-        exc = self._on_postgres_error('test', RuntimeError())
+        exc = self.on_postgres_error('test', RuntimeError())
         if isinstance(exc, RuntimeError):
             self.set_status(204)
         else:
@@ -156,9 +156,9 @@ class MultiRowRequestHandler(RequestHandler):
 
 class NoErrorRequestHandler(ErrorRequestHandler):
 
-    def _on_postgres_error(self,
-                           metric_name: str,
-                           exc: Exception) -> typing.Optional[Exception]:
+    def on_postgres_error(self,
+                          metric_name: str,
+                          exc: Exception) -> typing.Optional[Exception]:
         return None
 
 
@@ -228,9 +228,9 @@ class TimeoutErrorRequestHandler(RequestHandler):
         await self.postgres_execute(self.GET_SQL)
         raise web.HTTPError(500, 'This should have failed')
 
-    def _on_postgres_error(self,
-                           metric_name: str,
-                           exc: Exception) -> typing.Optional[Exception]:
+    def on_postgres_error(self,
+                          metric_name: str,
+                          exc: Exception) -> typing.Optional[Exception]:
         """Override for different error handling behaviors
 
         Return an exception if you would like for it to be raised, or swallow
@@ -253,9 +253,9 @@ class UnhandledExceptionRequestHandler(RequestHandler):
             raise web.HTTPError(422)
         raise web.HTTPError(500, 'This should have failed')
 
-    def _on_postgres_error(self,
-                           metric_name: str,
-                           exc: Exception) -> typing.Optional[Exception]:
+    def on_postgres_error(self,
+                          metric_name: str,
+                          exc: Exception) -> typing.Optional[Exception]:
         """Override for different error handling behaviors
 
         Return an exception if you would like for it to be raised, or swallow


### PR DESCRIPTION
The methods are intended to be overrideable, but the leading underscore convention conflicts with Python practice.

See https://docs.python.org/3.8/tutorial/classes.html#private-variables

Hesitant on adding backwards-compatible shims to the "public" methods because of the above documentation.