### PR TITLE
Fix postgres_status before first connection attempt

### DIFF
--- a/sprockets_postgres.py
+++ b/sprockets_postgres.py
@@ -408,7 +408,8 @@ class ApplicationMixin:
             }
 
         """
-        if not self._postgres_connected.is_set():
+        if not self._postgres_connected or \
+                not self._postgres_connected.is_set():
             return {
                 'available': False,
                 'pool_size': 0,

--- a/tests.py
+++ b/tests.py
@@ -349,6 +349,18 @@ class TestCase(testing.SprocketsHttpTestCase):
         return self.app
 
 
+class PostgresStatusTestCase(asynctest.TestCase):
+
+    async def test_postgres_status_before_first_connection(self):
+        app = Application()
+        status = await app.postgres_status()
+        self.assertEqual(
+            status,
+            {'available': False,
+             'pool_size': 0,
+             'pool_free': 0})
+
+
 class RequestHandlerMixinTestCase(TestCase):
 
     def test_postgres_status(self):


### PR DESCRIPTION
It's possible to call postgres_status before the first connection is established. Before this fix, an exception was raised due to `self._postgres_connected` being `None`.

```
  File "/home/ar/code/github/sprockets/sprockets-postgres/sprockets_postgres.py", line 411, in postgres_status
    if not self._postgres_connected.is_set():
AttributeError: 'NoneType' object has no attribute 'is_set'
```