### PR TITLE
DB metrics use a db subpath

### DIFF
--- a/sprockets_postgres.py
+++ b/sprockets_postgres.py
@@ -796,7 +796,7 @@ class RequestHandlerMixin:
         if hasattr(self, 'influxdb'):  # sprockets-influxdb
             self.influxdb.set_field(metric_name, duration)
         elif hasattr(self, 'record_timing'):  # sprockets.mixins.metrics
-            self.record_timing(duration, metric_name)
+            self.record_timing(duration, 'db', metric_name)
         else:
             LOGGER.debug('Postgres query %s duration: %s',
                          metric_name, duration)

--- a/tests.py
+++ b/tests.py
@@ -444,8 +444,9 @@ class RequestHandlerMixinTestCase(TestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(json.loads(response.body)['value'], expectation)
         self.app.record_timing.assert_called_once()
-        duration, metric_name = self.app.record_timing.call_args[0]
+        duration, metric_path, metric_name = self.app.record_timing.call_args[0]
         self.assertGreater(duration, 0.0)
+        self.assertEqual('db', metric_path)
         self.assertEqual('', metric_name)
 
     def test_postgres_multirow_get(self):


### PR DESCRIPTION
**What?**

For clients that use sprockets.mixins.metrics, DB metrics use a "db" subpath.

For example, if a program calls `self.postgres_execute` with `metric_name`='insert-user', that will record a metric on path
`db.insert-user`.

**Why?**

This is particularly beneficial for visualizing metrics. By querying Graphite for all metrics that have "db" in their path,
you can easily visualize all DB metrics for a program. If someone later adds another DB query and metric to that program,
it meets the same conditions, thus it can be automatically added to the graph. I need this.

Without this change, what is the alternative? You must identify each metric name both (1) in your program and (2) in the graph that visualizes DB metrics. This double data entry is more time-consuming and error-prone. Also a challenge to automate graph updates.

**Other Things to Note**

If you would like this concept to go further, I'm willing to entertain a configurable prefix for the DB metric path. Until then, an opinionated default seemed helpful.

Thanks in advance for reviewing this MR.